### PR TITLE
Add DeepSpot2Cell (NeurIPS 2025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Tag hints: `[Virtual Cell]`, `[Perturbation]`, `[Foundation Model]`, `[Spatial]`
 - **[Zero-Shot Benchmark]** `[Benchmark]` Systematic benchmarking of zero-shot utility and robustness in single-cell transcriptomic foundation models (**bioRxiv 2026**) [[paper](https://doi.org/10.64898/2026.06.18.733285)]
 
 - **[DeepSpot-M]** `[Virtual Cell]` DeepSpot-M: a multimodal foundation model for transcriptome-wide virtual spatial transcriptomics from histology (**medRxiv 2026**) [[paper](https://doi.org/10.64898/2026.06.19.26356060)] [[code](https://github.com/ratschlab/DeepSpotM)] ![GitHub stars](https://img.shields.io/github/stars/ratschlab/DeepSpotM.svg?logo=github&label=Stars)
+- **[DeepSpot2Cell]** `[Virtual Cell]` DeepSpot2Cell: Predicting Virtual Single-Cell Spatial Transcriptomics from H&E images using Spot-Level Supervision (**NeurIPS 2025**) [[paper](https://openreview.net/forum?id=ofCkwXQKaz)] [[code](https://github.com/ratschlab/DeepSpot2Cell)] ![GitHub stars](https://img.shields.io/github/stars/ratschlab/DeepSpot2Cell.svg?logo=github&label=Stars)
 
 - **[V3Cell]** `[Virtual Cell]` V3Cell: A Vision-Guided Virtual 3D Cell Framework for Phenotypic Modeling and Perturbation Prediction (**bioRxiv 2026**) [[paper](https://doi.org/10.64898/2026.06.23.734130)] [[code](https://github.com/Laineyoulu/V3Cell)] ![GitHub stars](https://img.shields.io/github/stars/Laineyoulu/V3Cell.svg?logo=github&label=Stars)
 


### PR DESCRIPTION
## Summary
- Add **DeepSpot2Cell** under Research Papers
- Title: DeepSpot2Cell: Predicting Virtual Single-Cell Spatial Transcriptomics from H&E images using Spot-Level Supervision
- Venue: NeurIPS 2025 Imageomics
- Paper: https://openreview.net/forum?id=ofCkwXQKaz
- Code: https://github.com/ratschlab/DeepSpot2Cell


Made with [Cursor](https://cursor.com)